### PR TITLE
Fix an eval bug

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -141,7 +141,7 @@ def tf_model_eval(sess, x, y, model, X_test, Y_test):
             # It's acceptable to repeat during training, but not eval.
             start = batch * FLAGS.batch_size
             end = min(len(X_test), start + FLAGS.batch_size)
-            cur_batch_size = end - start + 1
+            cur_batch_size = end - start
 
             # The last batch may be smaller than all others, so we need to
             # account for variable batch size here

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -43,7 +43,7 @@ def tf_model_loss(y, model, mean=True):
 
 
 def tf_model_train(sess, x, y, predictions, X_train, Y_train, save=False,
-                   predictions_adv=None):
+                   predictions_adv=None, evaluate=None):
     """
     Train a TF graph
     :param sess: TF session to use when training the graph
@@ -95,6 +95,8 @@ def tf_model_train(sess, x, y, predictions, X_train, Y_train, save=False,
                                           y: Y_train[start:end],
                                           keras.backend.learning_phase(): 1})
             assert end >= len(X_train) # Check that all examples were used
+            if evaluate is not None:
+                evaluate()
 
 
         if save:

--- a/tests/test_mnist_accuracy.py
+++ b/tests/test_mnist_accuracy.py
@@ -59,7 +59,7 @@ def main(argv=None):
 
         # Evaluate the accuracy of the MNIST model on legitimate test examples
         accuracy = tf_model_eval(sess, x, y, predictions, X_test, Y_test)
-        assert float(accuracy) >= 0.993, accuracy
+        assert float(accuracy) >= 0.98, accuracy
 
 
 if __name__ == '__main__':

--- a/tutorials/mnist_tutorial.md
+++ b/tutorials/mnist_tutorial.md
@@ -68,7 +68,8 @@ assert X_test.shape[0] == 10000, X_test.shape
 print 'Test accuracy on legitimate test examples: ' + str(accuracy)
 ```
 
-The accuracy returned should be above `99.3%`.
+The accuracy returned should be above `98%`.
+The accuracy can become much higher by training for more epochs.
 
 ## Crafting adversarial examples
 


### PR DESCRIPTION
- Prints out the test accuracy once per epoch instead of only at the end of training
- After I started doing that, I noticed it went >1 periodically. I fixed a bug in counting the number of examples seen during the evaluation process.
- Decreases the amount of accuracy we expect after 5 epochs in the tutorial / tests now that the accuracy is no longer overcounting