### PR TITLE
FGSM code refactoring, label fix

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -73,7 +73,7 @@ def tf_model_train(sess, model, X_train, Y_train, save=False,
     loss = tf_model_loss(y, model(x))
     if adversarial_training:
         from .attacks import fgsm_tf_symbolic
-        x_adv = fgsm_tf_symbolic(x, model, adv_eps, adv_clip_min, adv_clip_max)
+        x_adv = fgsm_tf_symbolic(x, y, model, adv_eps, adv_clip_min, adv_clip_max)
         loss = (loss + tf_model_loss(y, model(x_adv))) / 2
 
     train_step = tf.train.AdadeltaOptimizer(learning_rate=FLAGS.learning_rate, rho=0.95, epsilon=1e-08).minimize(loss)

--- a/tutorials/mnist_tutorial.py
+++ b/tutorials/mnist_tutorial.py
@@ -71,28 +71,26 @@ def main(argv=None):
     accuracy = tf_model_eval(sess, model, X_test_adv, Y_test)
     print('Test accuracy on adversarial examples: ' + str(accuracy))
 
-    # print("Repeating the process, using adversarial training")
-    # # Redefine TF model graph
-    # model_2 = model_mnist()
-    # predictions_2 = model_2(x)
-    # adv_x_2 = fgsm(x, predictions_2, eps=0.3)
-    # predictions_2_adv = model_2(adv_x_2)
-    #
-    #
-    # def evaluate_2():
-    #     # Evaluate the accuracy of the adversarialy trained MNIST model on
-    #     # legitimate test examples
-    #     accuracy = tf_model_eval(sess, model_2, X_test, Y_test)
-    #     print('Test accuracy on legitimate test examples: ' + str(accuracy))
-    #
-    #     # Evaluate the accuracy of the adversarially trained MNIST model on
-    #     # adversarial examples
-    #     accuracy_adv = tf_model_eval(sess, x, y, predictions_2_adv, X_test, Y_test)
-    #     print('Test accuracy on adversarial examples: ' + str(accuracy_adv))
-    #
-    # # Perform adversarial training
-    # tf_model_train(sess, x, y, predictions_2, X_train, Y_train, predictions_adv=predictions_2_adv,
-    #         evaluate=evaluate_2)
+    print("Repeating the process, using adversarial training")
+    # Redefine TF model graph
+    model_2 = model_mnist()
+
+
+    def evaluate_2():
+        # Evaluate the accuracy of the adversarialy trained MNIST model on
+        # legitimate test examples
+        accuracy = tf_model_eval(sess, model_2, X_test, Y_test)
+        print('Test accuracy on legitimate test examples: ' + str(accuracy))
+
+        # Evaluate the accuracy of the adversarially trained MNIST model on
+        # adversarial examples
+        X_test_adv_2 = fgsm(sess, model_2, X_test, eps=0.3)
+        accuracy_adv = tf_model_eval(sess, model_2, X_test_adv_2, Y_test)
+        print('Test accuracy on adversarial examples: ' + str(accuracy_adv))
+
+    # Perform adversarial training
+    tf_model_train(sess, model_2, X_train, Y_train, evaluate=evaluate_2,
+                   adversarial_training=True, adv_eps=0.3)
 
 
 if __name__ == '__main__':

--- a/tutorials/mnist_tutorial.py
+++ b/tutorials/mnist_tutorial.py
@@ -64,7 +64,7 @@ def main(argv=None):
 
 
     # Craft adversarial examples using Fast Gradient Sign Method (FGSM)
-    X_test_adv = fgsm(sess, model, X_test, eps=0.3)
+    X_test_adv = fgsm(sess, model, X_test, Y_test, eps=0.3)
     assert X_test_adv.shape[0] == 10000, X_test_adv.shape
 
     # Evaluate the accuracy of the MNIST model on adversarial examples
@@ -84,7 +84,7 @@ def main(argv=None):
 
         # Evaluate the accuracy of the adversarially trained MNIST model on
         # adversarial examples
-        X_test_adv_2 = fgsm(sess, model_2, X_test, eps=0.3)
+        X_test_adv_2 = fgsm(sess, model_2, X_test, Y_test, eps=0.3)
         accuracy_adv = tf_model_eval(sess, model_2, X_test_adv_2, Y_test)
         print('Test accuracy on adversarial examples: ' + str(accuracy_adv))
 


### PR DESCRIPTION
There are 3 important changes here:

1. Updated code style so that FGSM is consistent with JSMA. Both attacks should return a numpy array with the adversarial sample(s). Previously, FGSM returned a symbolic tensor that needed to be evaluated.
2. Improved general code style; user should not have to define TF placeholders when unnecessary.
3. Fixed FGSM algorithm; the adversary knows the _correct_ label for each sample they are trying to perturb, thus GT labels should be used to compute model loss, not model predictions. In the MNIST case this was a minor discrepancy (model achieves ~99% accuracy, so predictions and GT labels are roughly equivalent), but for other models this is more important.