### PR TITLE
Python 3 compatibility

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -49,7 +49,7 @@ def jsma(sess, x, predictions, grads, sample, target, theta, gamma=np.inf, incre
     """
     if back == 'tf':
         # Compute Jacobian-based saliency map attack using TensorFlow
-	from .attacks_tf import jsma_tf
+        from .attacks_tf import jsma_tf
         return jsma_tf(sess, x, predictions, grads, sample, target, theta, gamma, increase, clip_min, clip_max)
     elif back == 'th':
         raise NotImplementedError("Theano jsma not implemented.")

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -9,6 +9,7 @@ import itertools
 import numpy as np
 import tensorflow as tf
 import multiprocessing as mp
+from six.moves import xrange
 
 from . import utils_tf
 from . import utils
@@ -140,10 +141,10 @@ def jacobian(sess, x, grads, target, X):
     """
     # Prepare feeding dictionary for all gradient computations
     if 'keras' in sys.modules:
-	import keras
-	feed_dict = {x: X, keras.backend.learning_phase(): 0}
+        import keras
+        feed_dict = {x: X, keras.backend.learning_phase(): 0}
     else:
-	feed_dict = {x: X}
+        feed_dict = {x: X}
 
     # Initialize a numpy array to hold the Jacobian component values
     jacobian_val = np.zeros((FLAGS.nb_classes, FLAGS.img_rows, FLAGS.img_cols), dtype=np.float32)

--- a/cleverhans/utils.py
+++ b/cleverhans/utils.py
@@ -89,7 +89,7 @@ def other_classes(nb_classes, class_ind):
     :return: list of class indices without one class
     """
 
-    other_classes_list = list(xrange(nb_classes))
+    other_classes_list = list(range(nb_classes))
     other_classes_list.remove(class_ind)
 
     return other_classes_list

--- a/tutorials/mnist_tutorial_jsma.py
+++ b/tutorials/mnist_tutorial_jsma.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import keras
 import numpy as np
 import os
+from six.moves import xrange
 
 import tensorflow as tf
 from tensorflow.python.platform import app


### PR DESCRIPTION
Replace spurious tab by spaces and use range or xrange from six.moves.
In one place, I replaced xrange by range because the output was intended to be a list anyway.

Fixes #18 (but one might encourage to keep using spaces...)

Thank you for developing cleverhans.