### PR TITLE
Fix JSMA bug for odd-length inputs.

### DIFF
--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -244,7 +244,7 @@ def jsma_tf(sess, x, predictions, grads, sample, target, theta, gamma,
 
     # Repeat this main loop until we have achieved misclassification
     while (current != target and iteration < max_iters and
-           len(search_domain) > 0):
+           len(search_domain) > 1):
         # Reshape the adversarial example
         adv_x_original_shape = np.reshape(adv_x, original_shape)
 


### PR DESCRIPTION
When running JSMA, fix a bug where if the set of changable features
is odd, then it will crash if no solution is found instead of
returning failure.

This is triggered because JSMA assumes there are at least two pixels
that can be changed at any point in time. If there is only one, things
go bad.