### PR TITLE
Jsma fixes

### DIFF
--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -97,8 +97,8 @@ def saliency_map(grads_target, grads_other, search_domain, increase):
 
     # Remove the already-used input features from the search space
     invalid = list(set(range(nf)) - search_domain)
-    grads_target[invalid] = - int(increase) * np.max(grads_target)
-    grads_other[invalid] = - int(increase) * np.min(grads_other)
+    grads_target[invalid] = - (2 * int(increase) - 1) * np.max(grads_target)
+    grads_other[invalid] = - (2 * int(increase) - 1)* np.min(grads_other)
 
     # Create a 2D numpy array of the sum of grads_target and grads_other
     target_sum = grads_target.reshape((1, nf)) + grads_target.reshape((nf, 1))

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -121,8 +121,8 @@ def saliency_map(grads_target, grads_other, search_domain, increase):
     p1, p2 = best % nf, best // nf
 
     # Remove used pixels from our search domain
-    search_domain.remove(p1)
-    search_domain.remove(p2)
+    search_domain.discard(p1)
+    search_domain.discard(p2)
 
     return p1, p2, search_domain
 

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -97,8 +97,8 @@ def saliency_map(grads_target, grads_other, search_domain, increase):
 
     # Remove the already-used input features from the search space
     invalid = list(set(range(nf)) - search_domain)
-    grads_target[invalid] = 0
-    grads_other[invalid] = 0
+    grads_target[invalid] = - int(increase) * np.max(grads_target)
+    grads_other[invalid] = - int(increase) * np.min(grads_other)
 
     # Create a 2D numpy array of the sum of grads_target and grads_other
     target_sum = grads_target.reshape((1, nf)) + grads_target.reshape((nf, 1))

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -98,7 +98,7 @@ def saliency_map(grads_target, grads_other, search_domain, increase):
     # Remove the already-used input features from the search space
     invalid = list(set(range(nf)) - search_domain)
     grads_target[invalid] = - (2 * int(increase) - 1) * np.max(grads_target)
-    grads_other[invalid] = - (2 * int(increase) - 1)* np.min(grads_other)
+    grads_other[invalid] = - (2 * int(increase) - 1) * np.min(grads_other)
 
     # Create a 2D numpy array of the sum of grads_target and grads_other
     target_sum = grads_target.reshape((1, nf)) + grads_target.reshape((nf, 1))


### PR DESCRIPTION
Closes #121 

When no pixels satisfy the saliency map, the JSMA will try to `remove` the same pair of pixels multiple times from the `search_domain` list. Switched to `discard` (performance overhead is acceptable given that this case is not common afaik)

Some changes made in #106 created a bug by setting the gradients of pixels outside of the search domain to `0` (the value is not sufficiently extreme in order to guarantee that the pixel will not be selected as part of a pair when computing the saliency score)