### PR TITLE
make model_train compatible with multiple models in same TF sess

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -60,6 +60,29 @@ def model_loss(y, model, mean=True):
     return out
 
 
+def initialize_uninitialized_global_variables(sess):
+    """
+    Only initializes the variables of a TensorFlow session that were not
+    already initialized.
+    :param sess: the TensorFlow session
+    :return:
+    """
+    # List all global variables
+    global_vars = tf.global_variables()
+
+    # Find initialized status for all variables
+    is_var_init = [tf.is_variable_initialized(var) for var in global_vars]
+    is_initialized = sess.run(is_var_init)
+
+    # List all variables that were not initialized previously
+    not_initialized_vars = [var for (var, init) in
+                            zip(global_vars, is_initialized) if not init]
+
+    # Initialize all uninitialized variables found, if any
+    if len(not_initialized_vars):
+        sess.run(tf.variables_initializer(not_initialized_vars))
+
+
 def tf_model_train(*args, **kwargs):
     warnings.warn("`tf_model_train` is deprecated. Switch to `model_train`."
                   "`tf_model_train` will be removed after 2017-07-18.")
@@ -67,7 +90,8 @@ def tf_model_train(*args, **kwargs):
 
 
 def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
-                predictions_adv=None, evaluate=None, verbose=True, args=None):
+                predictions_adv=None, init_all=True, evaluate=None,
+                verbose=True, args=None):
     """
     Train a TF graph
     :param sess: TF session to use when training the graph
@@ -76,9 +100,15 @@ def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
     :param predictions: model output predictions
     :param X_train: numpy array with training inputs
     :param Y_train: numpy array with training outputs
-    :param save: boolean controling the save operation
+    :param save: boolean controlling the save operation
     :param predictions_adv: if set with the adversarial example tensor,
                             will run adversarial training
+    :param init_all: (boolean) If set to true, all TF variables in the session
+                     are (re)initialized, otherwise only previously
+                     uninitialized variables are initialized before training.
+    :param evaluate: function that is run after each training iteration
+                     (typically to display the test/validation accuracy).
+    :param verbose: (boolean) all print statements disabled when set to False.
     :param args: dict or argparse `Namespace` object.
                  Should contain `nb_epochs`, `learning_rate`,
                  `batch_size`
@@ -108,7 +138,10 @@ def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
 
     with sess.as_default():
         if hasattr(tf, "global_variables_initializer"):
-            tf.global_variables_initializer().run()
+            if init_all:
+                tf.global_variables_initializer().run()
+            else:
+                initialize_uninitialized_global_variables(sess)
         else:
             warnings.warn("Update your copy of tensorflow; future versions of "
                           "cleverhans may drop support for this version.")

--- a/tutorials/mnist_blackbox.py
+++ b/tutorials/mnist_blackbox.py
@@ -29,13 +29,13 @@ flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
 flags.DEFINE_float('learning_rate', 0.1, 'Learning rate for training')
 
 # Flags related to oracle
-flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
+flags.DEFINE_integer('nb_epochs', 10, 'Number of epochs to train model')
 
 # Flags related to substitute
-flags.DEFINE_integer('holdout', 100, 'Test set holdout for adversary')
+flags.DEFINE_integer('holdout', 150, 'Test set holdout for adversary')
 flags.DEFINE_integer('data_aug', 6, 'Nb of times substitute data augmented')
-flags.DEFINE_integer('nb_epochs_s', 6, 'Training epochs for each substitute')
-flags.DEFINE_float('lmbda', 0.2, 'Lambda in https://arxiv.org/abs/1602.02697')
+flags.DEFINE_integer('nb_epochs_s', 10, 'Training epochs for each substitute')
+flags.DEFINE_float('lmbda', 0.1, 'Lambda in https://arxiv.org/abs/1602.02697')
 
 
 def setup_tutorial():

--- a/tutorials/mnist_blackbox.py
+++ b/tutorials/mnist_blackbox.py
@@ -160,7 +160,7 @@ def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub):
             'learning_rate': FLAGS.learning_rate
         }
         model_train(sess, x, y, preds_sub, X_sub, to_categorical(Y_sub),
-                    verbose=False, args=train_params)
+                    init_all=False, verbose=False, args=train_params)
 
         # If we are not at last substitute training iteration, augment dataset
         if rho < FLAGS.data_aug - 1:


### PR DESCRIPTION
Closes #133 

When training successively two models in the same TF session, the second one reinitializes the variables of the first one (with the call to `model_train`). In the black-box tutorial, it is required to have both the black-box and substitute running at the same time.

This is fixed by adding an optional argument to model_train. When `all_init` is set to False, `model_train` only initialize variables that were not previously initialized.