### PR TITLE
model_eval bug fix, wrongly use of tf.argmax

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from distutils.version import LooseVersion
 import math
 import numpy as np
 import os
@@ -207,8 +208,12 @@ def model_eval(sess, x, y, model, X_test, Y_test, args=None):
     assert args.batch_size, "Batch size was not given in args dict"
 
     # Define accuracy symbolically
-    correct_preds = tf.equal(tf.argmax(y, axis=tf.rank(y) - 1),
-                             tf.argmax(model, axis=tf.rank(model) - 1))
+    if LooseVersion(tf.__version__) >= LooseVersion('1.0.0'):
+        correct_preds = tf.equal(tf.argmax(y, axis=-1),
+                                 tf.argmax(model, axis=-1))
+    else:
+        correct_preds = tf.equal(tf.argmax(y, axis=tf.rank(y) - 1),
+                                 tf.argmax(model, axis=tf.rank(model) - 1))
     acc_value = tf.reduce_mean(tf.to_float(correct_preds))
 
     # Init result var

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -207,7 +207,8 @@ def model_eval(sess, x, y, model, X_test, Y_test, args=None):
     assert args.batch_size, "Batch size was not given in args dict"
 
     # Define accuracy symbolically
-    correct_preds = tf.equal(tf.argmax(y, axis=-1), tf.argmax(model, axis=-1))
+    correct_preds = tf.equal(tf.argmax(y, axis=tf.rank(y) - 1),
+                             tf.argmax(model, axis=tf.rank(model) - 1))
     acc_value = tf.reduce_mean(tf.to_float(correct_preds))
 
     # Init result var


### PR DESCRIPTION
tf.argmax can't assign axis with -1, here is the official tutorial
```
axis: A Tensor. Must be one of the following types: int32, int64. int32, 0 <= axis < rank(input).
 Describes which axis of the input Tensor to reduce across. For vectors, use axis = 0.
```