### PR TITLE
Refine initialize_uninitialized_global_variables

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -66,20 +66,10 @@ def initialize_uninitialized_global_variables(sess):
     :param sess: the TensorFlow session
     :return:
     """
-    # List all global variables
     global_vars = tf.global_variables()
-
-    # Find initialized status for all variables
-    is_var_init = [tf.is_variable_initialized(var) for var in global_vars]
-    is_initialized = sess.run(is_var_init)
-
-    # List all variables that were not initialized previously
-    not_initialized_vars = [var for (var, init) in
-                            zip(global_vars, is_initialized) if not init]
-
-    # Initialize all uninitialized variables found, if any
-    if len(not_initialized_vars):
-        sess.run(tf.variables_initializer(not_initialized_vars))
+    uninitialized_variables = list(tf.get_variable(name) for name in
+            sess.run(tf.report_uninitialized_variables(global_vars)))
+    sess.run(tf.variables_initializer(uninitialized_variables))
 
 
 def tf_model_train(*args, **kwargs):


### PR DESCRIPTION
Use built-in function `tf.report_uninitialized_variables` to get uninitialized variables.